### PR TITLE
Make CommandT work with rxvt

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -138,6 +138,11 @@ nmap <D-0> g^
 if (&term == 'xterm')
   set t_Co=256
 endif
+" Make CommandT work with rxvt
+if (&term == 'rxvt-unicode' || &xterm == 'rxvt')
+  let g:CommandTSelectNextMap = ['<C-n>', '<C-j>', '<ESC>OB']
+  let g:CommandTSelectPrevMap = ['<C-p>', '<C-k>', '<ESC>OA']
+endif
 
 " Suppress lustyjuggler warnings
 let g:LustyJugglerSuppressRubyWarning = 1


### PR DESCRIPTION
Adam,
I finally figured out why arrow keys weren't working with commandT with me. Here's a patch to your vimrc that fixes it for rxvt-like terminals.
- Phil
